### PR TITLE
注文履歴一覧&詳細画面等レイアウト調整・選択ラベルの日本語化（支払方法）・会員の計算式関係修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,30 +3,50 @@ module ApplicationHelper
 
   def calculate_price_including_tax(price) #税込価格表示用メソッド設定（byみっころ）
     tax_rate = 1.08
-    total_price =(price * tax_rate).floor
-     number_to_currency(total_price, unit: "", delimiter: ",", precision: 0) #数字にカンマを追加し、小数点以下を表示せず、円マークを付けない
+    total_price =(price * tax_rate).round
+    number_to_currency(total_price, unit: "", delimiter: ",", precision: 0) #数字にカンマを追加し、小数点以下を表示せず、円マークを付けない
   end
 
   def format_price(price) #税抜価格表示用メソッド設定（byみっころ）
     number_to_currency(price, unit: "", delimiter: ",", precision: 0) # 数字にカンマを追加し、小数点以下を表示せず、円マークを付けない
   end
 
+  # def calculate_subtotal(cart_item) #小計表示用メソッド設定（byみっころ）
+  #   unit_price = cart_item.item.price
+  #   quantity = cart_item.amount
+  #   subtotal = unit_price * quantity
+  #   subtotal = unit_price * quantity
+  #   calculate_price_including_tax(subtotal)
+  # end
   def calculate_subtotal(cart_item) #小計表示用メソッド設定（byみっころ）
-    unit_price = cart_item.item.price
+    unit_price_including_tax = (cart_item.item.price * 1.08).round # 商品の税込価格を四捨五入
     quantity = cart_item.amount
-    subtotal = unit_price * quantity
-    calculate_price_including_tax(subtotal)
+    subtotal = unit_price_including_tax * quantity # 四捨五入された税込価格に数量を掛け算
+    number_to_currency(subtotal, unit: "", delimiter: ",", precision: 0) # 数字にカンマを追加し、小数点以下を表示せず、円マークを付けない
   end
+  
 
+  # def calculate_total(cart_items) #合計表示用メソッド設定（byみっころ）
+  #   return 0 unless cart_items.present? && cart_items.any? #追記（byみっころ）
+
+  #   total = cart_items.sum do |cart_item|
+  #     unit_price = cart_item.item.price
+  #     quantity = cart_item.amount
+  #     unit_price * quantity
+  #     (unit_price * quantity).round 
+  #   end
+  #   calculate_price_including_tax(total)
+  # end
   def calculate_total(cart_items) #合計表示用メソッド設定（byみっころ）
     return 0 unless cart_items.present? && cart_items.any? #追記（byみっころ）
-
+  
     total = cart_items.sum do |cart_item|
-      unit_price = cart_item.item.price
+      unit_price_including_tax = (cart_item.item.price * 1.08).round # 商品の税込価格を四捨五入
       quantity = cart_item.amount
-      unit_price * quantity
+      unit_price_including_tax * quantity # 四捨五入された税込価格に数量を掛け算
     end
-    calculate_price_including_tax(total)
+  
+    number_to_currency(total, unit: "", delimiter: ",", precision: 0) # 数字にカンマを追加し、小数点以下を表示せず、円マークを付けない
   end
 
   def calculate_total_with_shipping_fee(cart_items, shipping_fee) #追加（byみっころ）

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -25,7 +25,7 @@
         <% end %>
         
       <% else %>
-        <h4>販売停止中です</h4>
+        <h5><font color="red">販売停止中</font></h5>
       <% end %>
     </div>
   </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -24,7 +24,7 @@
                 </td>
                 <td style="border: 1px solid black;"><%= number_to_currency(cart_item.item.price * 1.08, unit: "", delimiter: ",", precision: 0) %></td>
                 <td style="border: 1px solid black;"><%= cart_item.amount %></td>
-                <td style="border: 1px solid black;"><%= number_to_currency(cart_item.item.price * cart_item.amount * 1.08, unit: "", delimiter: ",", precision: 0) %></td> <!-- 修正点: 小計を表示 -->
+                <td style="border: 1px solid black;"><%= number_to_currency((cart_item.item.price * 1.08).round * cart_item.amount, unit: "", delimiter: ",", precision: 0) %></td>
               </tr>
             <% end %>
             </tbody>
@@ -68,15 +68,17 @@
             <%= @selected_address %>
           </div>
           
-          <div class="text-center mt-5">
-            <%= form_with model: Order.new, url: orders_path, method: :post, local:true do %>
-              <%= hidden_field_tag :payment_type, @selected_pay %>
-              <%= hidden_field_tag :postal_code, @order.postal_code %>
-              <%= hidden_field_tag :address, @order.address %>
-              <%= hidden_field_tag :name, @order.name %>
-              <%= hidden_field_tag :shipping_cost, @shipping_fee %>
-              <%= submit_tag "注文を確定する", class: "btn btn-success" %>
-            <% end %>
+          <div class="col-8 offset-2 mt-5">
+            <div class="text-center">
+              <%= form_with model: Order.new, url: orders_path, method: :post, local:true do %>
+                <%= hidden_field_tag :payment_type, @selected_pay %>
+                <%= hidden_field_tag :postal_code, @order.postal_code %>
+                <%= hidden_field_tag :address, @order.address %>
+                <%= hidden_field_tag :name, @order.name %>
+                <%= hidden_field_tag :shipping_cost, @shipping_fee %>
+                <%= submit_tag "注文を確定する", class: "btn btn-success" %>
+              <% end %>
+            </div>
           </div>
 
       </div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -6,32 +6,32 @@
       <table class="table table-bordered">
         
         <tr>
-          <th>注文日</th>
-          <th>配送先</th>
-          <th>注文商品</th>
-          <th>支払金額</th>
-          <th>ステータス</th>
-          <th>注文詳細</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">注文日</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">配送先</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">注文商品</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">支払金額</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">ステータス</th>
+          <th style="background-color: #dcdcdc; border: 1px solid black;">注文詳細</th>
         </tr>
         
         <% @orders.each do |order| %>
           <tr>
-            <td><%= order.created_at.strftime("%Y/%m/%d") %></td>
-            <td>
+            <td style="border: 1px solid black;"><%= order.created_at.strftime("%Y/%m/%d") %></td>
+            <td style="border: 1px solid black;">
               〒<%= order.postal_code %><br>
               <%= order.address %><br>
               <%= order.customer.last_name %> <%= order.customer.first_name %>
             </td>
-            <td>
+            <td style="border: 1px solid black;">
               <ul class="list-unstyled">
                 <% order.order_details.each do |order_detail| %>
                   <li><%= order_detail.item.name %></li>
                 <% end %>
               </ul>
             </td>
-            <td><%= number_to_currency(order.total_payment, unit: "", delimiter: ",", precision: 0) %>円</td>
-            <td><%= order.status %></td>
-            <td><%= link_to "表示する", order_path(order), class: "btn btn-primary"%></td>
+            <td style="border: 1px solid black;"><%= number_to_currency(order.total_payment, unit: "", delimiter: ",", precision: 0) %>円</td>
+            <td style="border: 1px solid black;"><%= order.status %></td>
+            <td style="border: 1px solid black;"><%= link_to "表示する", order_path(order), class: "btn btn-primary"%></td>
           </tr>
         <% end %>
         

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -17,14 +17,14 @@
       
       <%= form_with model: @order, url: confirm_orders_path, method: :post, local: true do |f| %>
         
-        <h5 class="mt-3 mb-2"><strong>支払い方法</strong></h5>
-        <div style="margin-left: 2em">
-          <%= f.radio_button :payment_type, "クレジットカード" %>
-          <%= f.label :payment_type, I18n.t('activerecord.attributes.order.payment_type.0') %> <!--/config/locales/ja.ymlとlocales/en.yml &モデルで設定ししてます。（byみっころ）-->
+        <h5 class="mt-3 mb-2"><strong>支払方法</strong></h5>
+         <div style="margin-left: 2em">
+           <%= f.radio_button :payment_type, "クレジットカード" %>
+           <%= f.label :payment_type, "クレジットカード" %>
         </div>
         <div style="margin-left: 2em">
           <%= f.radio_button :payment_type, "銀行振込" %>
-          <%= f.label :payment_type, I18n.t('activerecord.attributes.order.payment_type.1') %> <!--/config/locales/ja.ymlとlocales/en.yml &モデルで設定ししてます。（byみっころ）-->
+          <%= f.label :payment_type, "銀行振込" %>
         </div>
       
         <div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -2,62 +2,60 @@
   <div class="row">
 
   <div class="col-12">
-    <h5><strong>注文履歴詳細</strong></h5>
+    <h4 class="mb-4" style="background-color: #dcdcdc;"><strong>注文履歴詳細</strong></h4>
 
     <p><strong>注文情報</strong></p>
-    <table class="table table-bordered">
+    <table class="table table-bordered col-8">
       <tr>
-        <td>注文日</td>
-        <td><%= @order.created_at.strftime('%Y/%m/%d') %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">注文日</th>
+        <td style="border: 1px solid black;"><%= @order.created_at.strftime('%Y/%m/%d') %></td>
       </tr>
       <tr>
-        <td>配送先</td>
-        <td>
-          〒<%= @order.postal_code %><br>
-           <%= @order.address %>
-           <%= @order.name %>
-        </td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">配送先</th>
+          <td style="border: 1px solid black;">
+            <%= session[:selected_address].gsub("　", "<br>").html_safe %>
+          </td>
       </tr>
       <tr>
-        <td>支払方法</td>
-        <td><%= @order.payment_type %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">支払方法</th>
+        <td style="border: 1px solid black;"><%= @order.payment_type %></td>
       </tr>
       <tr>
-        <td>ステータス</td>
-        <td><%= @order.status %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">ステータス</th>
+        <td style="border: 1px solid black;"><%= @order.status %></td>
       </tr>
     </table>
 
     <p><strong>請求情報</strong></p>
-    <table class="table table-bordered">
+    <table class="table table-bordered col-4 ">
       <tr>
-        <td>商品合計</td>
-        <td><%= calculate_total(@order.order_details) %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">商品合計</th>
+        <td style="border: 1px solid black;"><%= calculate_total(@order.order_details) %></td>
       </tr>
       <tr>
-        <td>配送料</td>
-        <td><%= @order.shipping_cost %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">配送料</th>
+        <td style="border: 1px solid black;"><%= @order.shipping_cost %></td>
       </tr>
       <tr>
-        <td><strong>ご請求額</strong></td>
-        <td><%= number_to_currency(@order.total_payment, unit: "", delimiter: ",", precision: 0) %></td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">ご請求額</th>
+        <td style="border: 1px solid black;"><%= number_to_currency(@order.total_payment, unit: "", delimiter: ",", precision: 0) %></td>
       </tr>
     </table>
 
     <p><strong>注文内容</strong></p>
-    <table class="table table-bordered">
+    <table class="table table-bordered col-10">
       <tr>
-        <td>商品</td>
-        <td>単価(税込)</td>
-        <td>個数</td>
-        <td>小計</td>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">商品</th>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">単価(税込)</th>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">個数</th>
+        <th style="background-color: #dcdcdc; border: 1px solid black;">小計</th>
       </tr>
       <% @order_details.each do |order_detail| %>
         <tr>
-          <td><%= order_detail.item.name %></td>
-          <td><%= number_to_currency(order_detail.item.price * 1.08, unit: "", delimiter: ",", precision: 0) %></td>
-          <td><%= order_detail.amount %></td>
-          <td><%= number_to_currency(calculate_price_including_tax(order_detail.item.price).to_i * order_detail.amount.to_i, unit: "", delimiter: ",", precision: 0) %></td>
+          <td style="border: 1px solid black;"><%= order_detail.item.name %></td>
+          <td style="border: 1px solid black;"><%= number_to_currency(order_detail.item.price * 1.08, unit: "", delimiter: ",", precision: 0) %></td>
+          <td style="border: 1px solid black;"><%= order_detail.amount %></td>
+          <td style="border: 1px solid black;"><%= number_to_currency((order_detail.item.price * 1.08).round * order_detail.amount, unit: "", delimiter: ",", precision: 0) %></td>
         </tr>
       <% end %>
     </table>


### PR DESCRIPTION
・レイアウトの調整
・おそらく全体の日本語化に伴う表記の変更？があったで、英語化されてしまった注文情報入力画面の「支払方法」ラベルを日本語に修正
・計算式の修正

上記を修正しました！